### PR TITLE
showOpenDialog check if canceled

### DIFF
--- a/describo-master/src/components/TargetSelection/LocalFolder.component.vue
+++ b/describo-master/src/components/TargetSelection/LocalFolder.component.vue
@@ -40,8 +40,10 @@ export default {
             let folder = await remote.dialog.showOpenDialog({
                 properties: ["openDirectory"],
             });
-            this.folder = folder.filePaths[0];
-            this.$emit("browse-target", { type: "local", folder: this.folder });
+            if(!folder.canceled){
+                this.folder = folder.filePaths[0];
+                this.$emit("browse-target", { type: "local", folder: this.folder });
+            }
         },
     },
 };


### PR DESCRIPTION
when no folder was selected, the target selection component was shown anyways and the target was undefined
"Bugfix"